### PR TITLE
Replace returned passed_name with effective command

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -35,7 +35,7 @@ jobs:
           default_python: "3.10"
           other_names: lint
   build:
-    name: ${{ matrix.name || matrix.passed_name || '?' }}
+    name: ${{ matrix.name || '?' }}
     runs-on: ${{ matrix.os || 'ubuntu-24.04' }}
     needs: pre
     strategy:
@@ -51,7 +51,7 @@ jobs:
           cache: pip
           python-version: ${{ matrix.python_version }}
       - run: pip3 install -U tox
-      - run: tox -e "${{ matrix.passed_name }}"
+      - run: "${{ matrix.command }}"
   codeql:
     name: codeql
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This is a breaking change that requires consumers to update their
workflows. Instead of returning the tox environment name to be
executed, the entire command is returned.

This also allows users to add custom commands into other_names if they
include a colon as a separator.
